### PR TITLE
Update bot_service.py

### DIFF
--- a/backend/services/bot_service.py
+++ b/backend/services/bot_service.py
@@ -7,17 +7,45 @@ from slack_sdk.errors import SlackApiError
 class BotService:
     def __init__(self):
         load_dotenv()
-        self.client = WebClient(environ["APP_OAUTH_TOKEN"])
-        self.secret = environ["SLACK_SIGNING_SECRET"]
+        self.client = self._initialize_client()
+        self.secret = environ.get("SLACK_SIGNING_SECRET")
+        if not self.secret:
+            raise ValueError("SLACK_SIGNING_SECRET is not set in the environment variables.")
+
+    def _initialize_client(self) -> WebClient:
+        #Initializes the Slack WebClient with the app's OAuth token.
+        app_oauth_token = environ.get("APP_OAUTH_TOKEN")
+        if not app_oauth_token:
+            raise ValueError("APP_OAUTH_TOKEN is not set in the environment variables.")
+        
+        return WebClient(token=app_oauth_token)
 
     def send_message(
         self, message: str, channel_name: str, *, thread_ts: str | None = None
-    ):
+    ) -> dict:
+        """
+        Sends a message to a Slack channel.
+
+        Args:
+            message (str): The message to send.
+            channel_name (str): The Slack channel where the message will be sent.
+            thread_ts (str | None, optional): The thread timestamp for threading messages. Defaults to None.
+
+        Returns:
+            dict: Response data from the Slack API.
+
+        Raises:
+            Exception: If the Slack API call fails.
+        """
         try:
-            # TODO: Handle response
-            self.client.chat_postMessage(
-                channel=channel_name, text=message, thread_ts=thread_ts, as_user=True
+            response = self.client.chat_postMessage(
+                channel=channel_name,
+                text=message,
+                thread_ts=thread_ts,
+                as_user=True
             )
-            return {"test": "test post request."}
+            return {"status": "success", "data": response.data}
+
         except SlackApiError as e:
-            raise Exception(e.response["error"])
+            error_message = f"Error sending message: {e.response.get('error', 'Unknown error')}"
+            raise Exception(error_message)


### PR DESCRIPTION
- Added checks to ensure APP_OAUTH_TOKEN and SLACK_SIGNING_SECRET are set in the environment variables. If they are missing, an exception is raised with a clear error message.

- Moved client initialization to a private method _initialize_client to separate responsibilities and ensure the constructor remains clean.

- The send_message method now returns a structured dictionary with status and data, which can be used for better debugging and integration with other systems.

- The send_message method uses Python 3.10+ type hints (e.g., str | None for thread_ts).